### PR TITLE
Add dependency for SilverStripe\Forms\LiteralField to SwiftypeSiteCnfg

### DIFF
--- a/src/Extensions/SwiftypeSiteConfig.php
+++ b/src/Extensions/SwiftypeSiteConfig.php
@@ -7,6 +7,7 @@ use SilverStripe\Assets\Image;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextareaField;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataExtension;
 


### PR DESCRIPTION
Add missing dependency for SilverStripe\Forms\LiteralField to avoid breaking settings section in CMS.