### PR TITLE
FIX: Change URL tag field type to enum, update readme

### DIFF
--- a/src/MetaTags/SwiftypeMetaTagURL.php
+++ b/src/MetaTags/SwiftypeMetaTagURL.php
@@ -22,5 +22,5 @@ class SwiftypeMetaTagURL extends SwiftypeMetaTag
     /**
      * @var string
      */
-    protected $fieldType = 'string';
+    protected $fieldType = 'enum';
 }


### PR DESCRIPTION
The URL meta tag field type is currently different to what is recommended in the [Swiftype documentation](https://swiftype.com/documentation/site-search/crawler-overview), so this is changing it from a string to an enum.

This will result in a `The current version of this page has a field type conflict` error upon inspecting a URL in swiftype, until the URL has been re indexed again. This doesn't seem to affect the page being initially indexed, however I am unsure if there are any other side effects.

See below image for the swiftype error on inspect, note that the types will be the other way around though.

![image](https://user-images.githubusercontent.com/7085702/53918191-39933c00-40cb-11e9-8ce5-7ac3ba9640e2.png)
