### PR TITLE
Handle missing URLs

### DIFF
--- a/src/Extensions/SwiftypeSiteTreeCrawlerExtension.php
+++ b/src/Extensions/SwiftypeSiteTreeCrawlerExtension.php
@@ -32,6 +32,11 @@ class SwiftypeSiteTreeCrawlerExtension extends SiteTreeExtension
     {
         parent::onAfterUnpublish();
 
+        // If the page has been entirely removed we don't have a url
+        if ($this->getOwner()->getAbsoluteLiveLink() === null) {
+            return;
+        }
+
         $this->forceSwiftypeIndex();
     }
 


### PR DESCRIPTION
`getAbsoluteLiveLink` has a chance of returning null, therefore we should handle that situation