### PR TITLE
Add version context to crawl url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,46 +1,47 @@
 {
-  "name": "ichaber/silverstripe-swiftype",
-  "description": "Use Swiftype search with Silverstripe",
-  "type": "silverstripe-vendormodule",
-  "homepage": "http://github.com/ichaber/silverstripe-swiftype",
-  "keywords": [
-    "silverstripe",
-    "swiftype",
-    "search"
-  ],
-  "license": "BSD-3-Clause",
-  "authors": [
-    {
-      "name": "Charlie Bergthaler",
-      "email": "charlie@silverstripe.com"
+    "name": "ichaber/silverstripe-swiftype",
+    "description": "Use Swiftype search with Silverstripe",
+    "type": "silverstripe-vendormodule",
+    "homepage": "http://github.com/ichaber/silverstripe-swiftype",
+    "keywords": [
+        "silverstripe",
+        "swiftype",
+        "search"
+    ],
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Charlie Bergthaler",
+            "email": "charlie@silverstripe.com"
+        },
+        {
+            "name": "Chris Penny",
+            "email": "cpenny@silverstripe.com"
+        }
+    ],
+    "support": {
+        "issues": "http://github.com/ichaber/silverstripe-swiftype/issues"
     },
-    {
-      "name": "Chris Penny",
-      "email": "cpenny@silverstripe.com"
-    }
-
-  ],
-  "support": {
-    "issues": "http://github.com/ichaber/silverstripe-swiftype/issues"
-  },
-  "require": {
-    "php": "^7.1",
-    "silverstripe/vendor-plugin": "^1",
-    "silverstripe/framework": "^4",
-    "silverstripe/cms": "^4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7"
-  },
-  "autoload": {
-    "psr-4": {
-      "Ichaber\\SSSwiftype\\": "src/",
-      "Ichaber\\SSSwiftype\\Tests\\": "tests/"
-    }
-  },
-  "extra": {
-    "installer-name": "silverstripe-swiftype"
-  },
-  "prefer-stable": true,
-  "minimum-stability": "dev"
+    "require": {
+        "php": "^7.1",
+        "silverstripe/vendor-plugin": "^1",
+        "silverstripe/framework": "^4",
+        "silverstripe/cms": "^4",
+        "guzzlehttp/guzzle": "^6.3.0",
+        "guzzlehttp/psr7": "^1.4.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ichaber\\SSSwiftype\\": "src/",
+            "Ichaber\\SSSwiftype\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "installer-name": "silverstripe-swiftype"
+    },
+    "prefer-stable": true,
+    "minimum-stability": "dev"
 }

--- a/src/Service/SwiftypeCrawler.php
+++ b/src/Service/SwiftypeCrawler.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Service;
+
+use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use Throwable;
+
+/**
+ * Credit: [Bernard Hamlin](https://github.com/blueo) and [Mojmir Fendek](https://github.com/mfendeksilverstripe)
+ *
+ * Class SwiftypeCrawler
+ *
+ * @package Ichaber\SSSwiftype\Service
+ */
+class SwiftypeCrawler
+{
+    use Injectable;
+
+    const SWIFTYPE_API = 'https://api.swiftype.com/api/v1/engines/%s/domains/%s/crawl_url.json';
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array
+     */
+    private $messages = [];
+
+    /**
+     * Crawler constructor.
+     *
+     * @param Client|null $client
+     */
+    public function __construct(?Client $client = null)
+    {
+        if ($client === null) {
+            $client = new Client();
+        }
+
+        $this->client = $client;
+    }
+
+    /**
+     * Crawls a page based on the locale
+     *
+     * @param string $url
+     * @param mixed|null $additionalData If set, we assume that you want to populate your Credentials through extension
+     * @return bool
+     */
+    public function send(string $url, $additionalData = null): bool
+    {
+        $credentials = SwiftypeCredentials::create($additionalData);
+        if (!$credentials->isEnabled()) {
+            $this->addMessage($credentials->getMessage());
+            $this->getLogger()->alert($credentials->getMessage());
+
+            return false;
+        }
+
+        $swiftypeEndpoint = sprintf(
+            self::SWIFTYPE_API,
+            $credentials->getEngineSlug(),
+            $credentials->getDomainID()
+        );
+
+        try {
+            $response = $this->client->put(
+                $swiftypeEndpoint,
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    'body' => json_encode([
+                        'auth_token' => $credentials->getAPIKey(),
+                        'url' => $url,
+                    ]),
+                ]
+            );
+
+            $contents = $response->getBody()->getContents();
+        } catch (Throwable $e) {
+            $message = sprintf('Exception %s for url: %s message: %s', get_class($e), $url, $e->getMessage());
+
+            $this->addMessage($message);
+            $this->getLogger()->alert($message);
+
+            return false;
+        }
+
+        // invalid response code
+        if (strpos((string) $response->getStatusCode(), '2') !== 0) {
+            $message = sprintf(
+                "Swiftype Crawl request failed - invalid response code \n%s\n%s\n%s",
+                $response->getStatusCode(),
+                json_encode($response->getHeaders()),
+                $contents
+            );
+
+            $this->addMessage($message);
+            $this->getLogger()->alert($message);
+
+            return false;
+        }
+
+        // invalid response data
+        $data = json_decode($contents, true);
+        if ($data && array_key_exists('error', $data)) {
+            $message = sprintf(
+                "Swiftype Crawl request failed - invalid response data \n%s\n%s\n%s",
+                $response->getStatusCode(),
+                json_encode($response->getHeaders()),
+                $contents
+            );
+
+            $this->addMessage($message);
+            $this->getLogger()->alert($message);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    protected function getLogger(): LoggerInterface
+    {
+        if (!$this->logger) {
+            $this->logger = Injector::inst()->get(LoggerInterface::class);
+        }
+
+        return $this->logger;
+    }
+
+    /**
+     * @param string $message
+     */
+    protected function addMessage(string $message): void
+    {
+        $this->messages[] = $message;
+    }
+}

--- a/src/Service/SwiftypeCredentials.php
+++ b/src/Service/SwiftypeCredentials.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Service;
+
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Credit: [Bernard Hamlin](https://github.com/blueo) and [Mojmir Fendek](https://github.com/mfendeksilverstripe)
+ *
+ * Class SwiftypeCredentials
+ *
+ * @package Ichaber\SSSwiftype\Service
+ */
+class SwiftypeCredentials
+{
+    use Extensible;
+    use Injectable;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var bool
+     */
+    private $enabled = false;
+
+    /**
+     * @var string|null
+     */
+    private $engineSlug;
+
+    /**
+     * @var string|null
+     */
+    private $domainID;
+
+    /**
+     * @var string|null
+     */
+    private $apiKey;
+
+    /**
+     * @var string|null
+     */
+    private $message;
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool|null $enabled
+     */
+    public function setEnabled(?bool $enabled): void
+    {
+        $this->enabled = (bool) $enabled;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEngineSlug(): ?string
+    {
+        return $this->engineSlug;
+    }
+
+    /**
+     * @param string|null $engineSlug
+     */
+    public function setEngineSlug(?string $engineSlug): void
+    {
+        $this->engineSlug = $engineSlug;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDomainID(): ?string
+    {
+        return $this->domainID;
+    }
+
+    /**
+     * @param string|null $domainID
+     */
+    public function setDomainID(?string $domainID): void
+    {
+        $this->domainID = $domainID;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAPIKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * @param string|null $apiKey
+     */
+    public function setAPIKey(?string $apiKey): void
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function setMessage(string $message): void
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Gets the Swiftype credentials
+     *
+     * @param mixed|null $additionalData If set, we assume that you want to populate your Credentials through extension
+     * @return void
+     */
+    public function __construct($additionalData = null)
+    {
+        if ($additionalData !== null) {
+            // You've supplied the class with $additionalData, so, please populate your Credentials data through the
+            // populateCredentials extensions point. It will have access to your $additionalData also
+            $this->invokeWithExtensions('populateCredentials', $additionalData);
+        } else {
+            // Default functionality is to grab Credentials from SiteConfig
+            /** @var SiteConfig $config */
+            $config = SiteConfig::current_site_config();
+
+            // You might want to implement this via Environment variables or something. Just make sure SiteConfig has
+            // access to that variable, and return it here
+            $this->setEnabled((bool) $config->relField('SwiftypeEnabled'));
+
+            // If you have multiple Engines per site (maybe you use Fluent with a different Engine on each Locale), then
+            // this provides some basic ability to have different credentials returned based on the application state
+            $this->setEngineSlug($config->relField('SwiftypeEngineSlug'));
+            $this->setDomainID($config->relField('SwiftypeDomainID'));
+            $this->setAPIKey($config->relField('SwiftypeAPIKey'));
+        }
+
+        if (!$this->isEnabled()) {
+            $this->disable(
+                'Swiftype is disabled. It can be enabled under Settings > Swiftype Search'
+            );
+
+            return;
+        }
+
+        if (!$this->getEngineSlug()) {
+            $this->disable(
+                'Swiftype Engine Slug value has not been set. Settings > Swiftype Search > Swiftype Engine Slug'
+            );
+
+            return;
+        }
+
+        if (!$this->getDomainID()) {
+            $this->disable(
+                'Swiftype Domain ID has not been set. Settings > Swiftype Search > Swiftype Domain ID'
+            );
+
+            return;
+        }
+
+        if (!$this->getAPIKey()) {
+            $this->disable(
+                'Swiftype API Key has not been set. Settings > Swiftype Search > Swiftype Production API Key'
+            );
+
+            return;
+        }
+    }
+
+    /**
+     * @param string $message
+     */
+    protected function disable(string $message): void
+    {
+        $trace = debug_backtrace();
+
+        // array_shift for adding context (for RaygunHandler) by using the last item on the stack trace.
+        $this->getLogger()->warning($message, array_shift($trace));
+
+        $this->setMessage($message);
+        $this->setEnabled(false);
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    protected function getLogger(): LoggerInterface
+    {
+        if (!$this->logger) {
+            $this->logger = Injector::inst()->get(LoggerInterface::class);
+        }
+
+        return $this->logger;
+    }
+}

--- a/tests/php/Extensions/SwiftypeSiteTreeCrawlerExtensionTest.php
+++ b/tests/php/Extensions/SwiftypeSiteTreeCrawlerExtensionTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Tests\Extensions;
+
+use Exception;
+use Ichaber\SSSwiftype\Extensions\SwiftypeSiteTreeCrawlerExtension;
+use Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * Class SwiftypeMetaTagContentExtensionTest
+ *
+ * @package Ichaber\SSSwiftype\Tests\Extensions
+ */
+class SwiftypeSiteTreeCrawlerExtensionTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'SwiftypeSiteTreeCrawlerExtensionTest.yml';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Make sure that our cache is cleared between tests
+        /** @var SwiftypeSiteTreeCrawlerExtension $crawlerExtension */
+        $crawlerExtension = Injector::inst()->get(SwiftypeSiteTreeCrawlerExtension::class);
+        $crawlerExtension->clearCacheAll();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUrlsToCrawlPublished(): void
+    {
+        // Set our config to not clear caches after un/publish, so that we can easily fetch the Urls for our test
+        Config::inst()->update(
+            SwiftypeSiteTreeCrawlerExtension::class,
+            'clear_cache_disabled',
+            true
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page1');
+
+        // Publish single so that Urls to crawl is populated
+        $page->publishSingle();
+        $key = str_replace('\\', '', $page->ClassName . $page->ID);
+
+        $expectedUrls = [
+            'localhost/page1/',
+        ];
+        $urls = [];
+
+        // Grab the Urls that we expect to have been collated
+        $urlsToCrawl = $page->getUrlsToCrawl();
+
+        // Check that the key exists for our page
+        $this->assertArrayHasKey($key, $urlsToCrawl);
+
+        // Grab the Urls that are for our page
+        $urlsToCrawl = $urlsToCrawl[$key];
+
+        // Strip out any http/https stuff
+        foreach ($urlsToCrawl as $urlToCrawl) {
+            $url = str_replace('http://', '', $urlToCrawl);
+            $url = str_replace('https://', '', $url);
+
+            $urls[] = $url;
+        }
+
+        $this->assertEquals($expectedUrls, $urls, '', 0.0, 10, true);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUrlsToCrawlUnpublished(): void
+    {
+        // Set our config to not clear caches after un/publish, so that we can easily fetch the Urls for our test
+        Config::inst()->update(
+            SwiftypeSiteTreeCrawlerExtension::class,
+            'clear_cache_disabled',
+            true
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page2');
+
+        // Make sure our page is published before we begin
+        $page->publishSingle();
+        $key = str_replace('\\', '', $page->ClassName . $page->ID);
+
+        // Make sure we don't have any Cache set from the above publishing
+        $page->flushCache();
+
+        $page->doUnpublish();
+
+        $expectedUrls = [
+            'localhost/page2/',
+        ];
+        $urls = [];
+
+        // Grab the Urls that we expect to have been collated
+        $urlsToCrawl = $page->getUrlsToCrawl();
+
+        // Check that the key exists for our page
+        $this->assertArrayHasKey($key, $urlsToCrawl);
+
+        // Grab the Urls that are for our page
+        $urlsToCrawl = $urlsToCrawl[$key];
+
+        // Strip out any http/https stuff
+        foreach ($urlsToCrawl as $urlToCrawl) {
+            $url = str_replace('http://', '', $urlToCrawl);
+            $url = str_replace('https://', '', $url);
+
+            $urls[] = $url;
+        }
+
+        $this->assertEquals($expectedUrls, $urls, '', 0.0, 10, true);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUrlsToCrawlSegmentChanged(): void
+    {
+        // Set our config to not clear caches after un/publish, so that we can easily fetch the Urls for our test
+        Config::inst()->update(
+            SwiftypeSiteTreeCrawlerExtension::class,
+            'clear_cache_disabled',
+            true
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page3');
+
+        // Make sure our page is published before we begin
+        $page->publishSingle();
+        $key = str_replace('\\', '', $page->ClassName . $page->ID);
+
+        // Make sure our cache is flushed from the above publishing
+        $page->flushCache();
+
+        // Update our URL Segment
+        $page->URLSegment = 'page3Changed';
+        // Publish single so that Urls to crawl is populated
+        $page->publishSingle();
+
+        // We expect two Urls now. One from before the segment change, and one from after it
+        $expectedUrls = [
+            'localhost/page3/',
+            'localhost/page3changed/',
+        ];
+        $urls = [];
+
+        // Grab the Urls that we expect to have been collated
+        $urlsToCrawl = $page->getUrlsToCrawl();
+
+        // Check that the key exists for our page
+        $this->assertArrayHasKey($key, $urlsToCrawl);
+
+        // Grab the Urls that are for our page
+        $urlsToCrawl = $urlsToCrawl[$key];
+
+        // Strip out any http/https stuff
+        foreach ($urlsToCrawl as $urlToCrawl) {
+            $url = str_replace('http://', '', $urlToCrawl);
+            $url = str_replace('https://', '', $url);
+
+            $urls[] = $url;
+        }
+
+        $this->assertEquals($expectedUrls, $urls, '', 0.0, 10, true);
+    }
+
+    public function testUrlsToCrawlCacheCleared(): void
+    {
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page1');
+
+        // Publish single so that Urls to crawl is populated
+        $page->publishSingle();
+        $key = str_replace('\\', '', $page->ClassName . $page->ID);
+
+        // Grab the Urls that we expect to have been collated
+        $urlsToCrawl = $page->getUrlsToCrawl();
+
+        // Check that the key exists for our page
+        $this->assertArrayNotHasKey($key, $urlsToCrawl);
+    }
+}

--- a/tests/php/Extensions/SwiftypeSiteTreeCrawlerExtensionTest.yml
+++ b/tests/php/Extensions/SwiftypeSiteTreeCrawlerExtensionTest.yml
@@ -1,0 +1,13 @@
+Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree:
+  page1:
+    URLSegment: page1
+    Title: Page 1
+    MetaDescription: Page 1 Meta Description
+  page2:
+    URLSegment: page2
+    Title: Page 2
+    MetaDescription: Page 2 Meta Description
+  page3:
+    URLSegment: page3
+    Title: Page 3
+    MetaDescription: Page 3 Meta Description

--- a/tests/php/Fake/SwiftypeSiteTree.php
+++ b/tests/php/Fake/SwiftypeSiteTree.php
@@ -3,6 +3,7 @@
 namespace Ichaber\SSSwiftype\Tests\Fake;
 
 use Ichaber\SSSwiftype\Extensions\SwiftypeMetaTagContentExtension;
+use Ichaber\SSSwiftype\Extensions\SwiftypeSiteTreeCrawlerExtension;
 use Ichaber\SSSwiftype\Tests\Extensions\SwiftypeMetaTagContentExtensionTest;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
@@ -12,6 +13,7 @@ use SilverStripe\Dev\TestOnly;
  *
  * @package Ichaber\SSSwiftype\Tests\Fake
  * @mixin SwiftypeMetaTagContentExtension
+ * @mixin SwiftypeSiteTreeCrawlerExtension
  */
 class SwiftypeSiteTree extends SiteTree implements TestOnly
 {
@@ -20,6 +22,7 @@ class SwiftypeSiteTree extends SiteTree implements TestOnly
      */
     private static $extensions = [
         SwiftypeMetaTagContentExtension::class,
+        SwiftypeSiteTreeCrawlerExtension::class,
     ];
 
     /**

--- a/tests/php/Service/SwiftypeCrawlerTest.php
+++ b/tests/php/Service/SwiftypeCrawlerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Tests\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use Ichaber\SSSwiftype\Extensions\SwiftypeSiteConfigFieldsExtension;
+use Ichaber\SSSwiftype\Service\SwiftypeCrawler;
+use SilverStripe\Dev\SapphireTest;
+use GuzzleHttp\Psr7\Response;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Class SwiftypeCrawlerTest
+ *
+ * @package Ichaber\SSSwiftype\Tests\Service
+ */
+class SwiftypeCrawlerTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'SwiftypeCrawlerTest.yml';
+
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        SiteConfig::class => [
+            SwiftypeSiteConfigFieldsExtension::class,
+        ],
+    ];
+
+    /**
+     * Test that a crawl will succeed
+     */
+    public function testCrawlSuccess(): void
+    {
+        $responseCode = 201;
+        $mock = new MockHandler([
+            new Response($responseCode),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $crawler = SwiftypeCrawler::create($client);
+
+        // True represents a successful crawl request
+        $this->assertTrue($crawler->send('https://www.someurl.com'));
+    }
+
+    /**
+     * Test that a crawl will fail on invalid response code
+     */
+    public function testCrawlFailResponseCode(): void
+    {
+        $responseCode = 301;
+        $mock = new MockHandler([
+            new Response($responseCode),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $crawler = SwiftypeCrawler::create($client);
+
+        $expectedMessage = sprintf(
+            "Swiftype Crawl request failed - invalid response code \n%s\n%s\n%s",
+            $responseCode,
+            json_encode([]),
+            ''
+        );
+
+        $this->assertFalse($crawler->send('https://www.someurl.com'));
+        $this->assertEquals($expectedMessage, $crawler->getMessages()[0]);
+    }
+
+    /**
+     * Test that a crawl will fail in invalid response data
+     */
+    public function testCrawlFailResponseData(): void
+    {
+        $responseCode = 200;
+        $mockBody = json_encode([
+            'error' => 'test error message',
+        ]);
+        $mock = new MockHandler([
+            new Response($responseCode, [], $mockBody),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $crawler = SwiftypeCrawler::create($client);
+
+        $expectedMessage = sprintf(
+            "Swiftype Crawl request failed - invalid response data \n%s\n%s\n%s",
+            $responseCode,
+            json_encode([]),
+            $mockBody
+        );
+
+        $this->assertFalse($crawler->send('https://www.someurl.com'));
+        $this->assertEquals($expectedMessage, $crawler->getMessages()[0]);
+    }
+
+    /**
+     * Test that a crawl will fail
+     */
+    public function testCrawlError(): void
+    {
+        $mock = new MockHandler([
+            new RequestException("Error Communicating with Server", new Request('GET', 'test')),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $crawler = SwiftypeCrawler::create($client);
+
+        $url = 'https://www.someurl.com';
+        // Lets run it and get a not good response
+        $expectedMessage = sprintf(
+            'Exception %s for url: %s message: Error Communicating with Server',
+            RequestException::class,
+            $url
+        );
+
+        $this->assertFalse($crawler->send($url));
+        $this->assertEquals($expectedMessage, $crawler->getMessages()[0]);
+    }
+}

--- a/tests/php/Service/SwiftypeCrawlerTest.yml
+++ b/tests/php/Service/SwiftypeCrawlerTest.yml
@@ -1,0 +1,6 @@
+SilverStripe\SiteConfig\SiteConfig:
+  config:
+    SwiftypeEnabled: 1
+    SwiftypeEngineSlug: test
+    SwiftypeDomainID: test
+    SwiftypeAPIKey: test

--- a/tests/php/Service/SwiftypeCredentialsTest.php
+++ b/tests/php/Service/SwiftypeCredentialsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Tests\Service;
+
+use Ichaber\SSSwiftype\Service\SwiftypeCredentials;
+use Ichaber\SSSwiftype\Extensions\SwiftypeSiteConfigFieldsExtension;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Class SwiftypeCredentialsTest
+ *
+ * @package Ichaber\SSSwiftype\Tests\Service
+ */
+class SwiftypeCredentialsTest extends SapphireTest
+{
+    /**
+     * @var bool
+     */
+    protected $usesDatabase = true;
+
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        SiteConfig::class => [
+            SwiftypeSiteConfigFieldsExtension::class,
+        ],
+    ];
+
+    /**
+     * @throws ValidationException
+     */
+    public function testFullCredentials(): void
+    {
+        /** @var SiteConfig|SwiftypeSiteConfigFieldsExtension $config */
+        $config = SiteConfig::current_site_config();
+
+        $config->SwiftypeEnabled = 1;
+        $config->SwiftypeEngineSlug = 'test';
+        $config->SwiftypeDomainID = 'test';
+        $config->SwiftypeAPIKey = 'test';
+
+        $config->write();
+
+        $credentials = SwiftypeCredentials::create();
+
+        $this->assertTrue($credentials->isEnabled());
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testNoEngineSlug(): void
+    {
+        /** @var SiteConfig|SwiftypeSiteConfigFieldsExtension $config */
+        $config = SiteConfig::current_site_config();
+
+        $config->SwiftypeEnabled = 1;
+        $config->SwiftypeEngineSlug = null;
+        $config->SwiftypeDomainID = 'test';
+        $config->SwiftypeAPIKey = 'test';
+
+        $config->write();
+
+        $credentials = SwiftypeCredentials::create();
+
+        $this->assertFalse($credentials->isEnabled());
+        $this->assertContains('Swiftype Engine Slug value has not been set', $credentials->getMessage());
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testNoDomainID(): void
+    {
+        /** @var SiteConfig|SwiftypeSiteConfigFieldsExtension $config */
+        $config = SiteConfig::current_site_config();
+
+        $config->SwiftypeEnabled = 1;
+        $config->SwiftypeEngineSlug = 'test';
+        $config->SwiftypeDomainID = null;
+        $config->SwiftypeAPIKey = 'test';
+
+        $config->write();
+
+        $credentials = SwiftypeCredentials::create();
+
+        $this->assertFalse($credentials->isEnabled());
+        $this->assertContains('Swiftype Domain ID has not been set', $credentials->getMessage());
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testNoApiKey(): void
+    {
+        /** @var SiteConfig|SwiftypeSiteConfigFieldsExtension $config */
+        $config = SiteConfig::current_site_config();
+
+        $config->SwiftypeEnabled = 1;
+        $config->SwiftypeEngineSlug = 'test';
+        $config->SwiftypeDomainID = 'test';
+        $config->SwiftypeAPIKey = null;
+
+        $config->write();
+
+        $credentials = SwiftypeCredentials::create();
+
+        $this->assertFalse($credentials->isEnabled());
+        $this->assertContains('Swiftype API Key has not been set', $credentials->getMessage());
+    }
+}


### PR DESCRIPTION
Fixed #5 
Fixed #8 

We need to update our process to collate Urls at the appropriate times, and then separately process those Urls at the appropriate times. These two processes can't always occur within the same `on` extension point.

EG:

- When a Page is unpublished, we need to determine the Live Link before the record is unpublished, and then process that Link afterwards (in case something went wrong during the unpublish process)
- When a Page has its URL Segment updated, we need to determine the old Live Link before that change is saved, and then determine the new Live Link after.