### PR TITLE
FIX PHP 7.3 warnings (and add CI for it)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1 PHPUNIT_COVERAGE_TEST=1
+    - php: 7.3
+      env: DB=MYSQL PHPUNIT_TEST=1
 
 before_script:
   # Init PHP

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-cms:1.0.x-dev
+  - composer require --no-update silverstripe/recipe-cms:4.x-dev
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     "silverstripe/cms": "^4",
     "silverstripe/framework": "^4"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7"
+  },
   "autoload": {
     "psr-4": {
       "Ichaber\\SSSwiftype\\Tests\\": "tests/php/",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
   },
   "autoload": {
     "psr-4": {
+      "Ichaber\\SSSwiftype\\Tests\\": "tests/php/",
       "Ichaber\\SSSwiftype\\": "src/"
     }
   },
@@ -36,5 +37,7 @@
     "installer-name": "silverstripe-swiftype",
     "screenshots": [
     ]
-  }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/src/Extensions/SwiftypeMetaTagContentExtension.php
+++ b/src/Extensions/SwiftypeMetaTagContentExtension.php
@@ -26,7 +26,7 @@ class SwiftypeMetaTagContentExtension extends DataExtension
         $metaClasses = $this->owner->config()->get('swiftype_meta_tag_classes');
         $metaTags = [];
 
-        if (count($metaClasses) === 0) {
+        if (!is_array($metaClasses) || count($metaClasses) === 0) {
             return DBField::create_field('HTMLText', '');
         }
 

--- a/tests/php/MetaTags/SwiftypeMetaTagContentExtensionTest.php
+++ b/tests/php/MetaTags/SwiftypeMetaTagContentExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Ichaber\SSSwiftype\Tests\Extensions;
+
+use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagDescription;
+use SilverStripe\Dev\SapphireTest;
+use Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+
+/**
+ * Tests SwiftypeMetaTagContentExtension implicitly,
+ * it's added on {@link SwiftypeSiteTree}.
+ */
+class SwiftypeMetaTagContentExtensionTest extends SapphireTest
+{
+    public function testMetaTagsReturnsEmptyByDefault()
+    {
+        $page = new SwiftypeSiteTree();
+        /** @var DBHTMLText $tags */
+        $tags = $page->getSwiftypeMetaTags();
+        $this->assertEmpty($tags->getValue());
+    }
+
+    public function testMetaTagsReturnsConfiguredTags()
+    {
+        $page = new SwiftypeSiteTree();
+        $page->MetaDescription = 'My description';
+        $page->config()->update('swiftype_meta_tag_classes', [
+            SwiftypeMetaTagDescription::class
+        ]);
+
+        /** @var DBHTMLText $tags */
+        $tags = $page->getSwiftypeMetaTags();
+        $this->assertNotEmpty($tags->getValue());
+        $this->assertContains($page->MetaDescription, $tags->getValue());
+    }
+}


### PR DESCRIPTION
We don't validate the YAML "schema", so should deal with it gracefully in PHP.
swiftype_meta_tag_classes can be optionally configured on owner objects,
there's no defaults - so we should check if it's an array first.

This started breaking on PHP 7.3 with E_WARNING, see
https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types