### PR TITLE
FEATURE: Add meta tag for noindex and ShowInSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 
 # *WARNING*
 
-This module is still under development, trying to standardize existing custom code and is currently tailored towards using the Swiftype crawler for indexing.
-The ultimate goal is to have a drop in module for every silverstripe-swiftype project and eventually feed it back into the silverstripe space.
+This module is still under development, trying to standardize existing custom code and is currently tailored towards
+using the Swiftype crawler for indexing.
+
+The ultimate goal is to have a drop in module for every silverstripe-swiftype project and eventually feed it back into
+the silverstripe space.
 
 ## Installation
 
@@ -17,41 +20,47 @@ Install with Composer:
 composer require ichabar/silverstripe-swiftype
 ```
 
+Also see [Configuration](#Configuration). Extensions and configurations are not applied automatically.
+
 ## Documentation
 
-This module is based on work Chris Penny (https://github.com/chrispenny) did and aims pack it as a module to allow it to be reused and support SilverStripe 4+.
- 
-Provides the necessary code for configuring the swiftype integration code with the access key and for adding metadata tags to the site code so the Swiftype crawler can be index them.
+Provides the necessary code for configuring the swiftype integration code with the access key and for adding metadata
+tags to the site code so the Swiftype crawler can be index them.
 
-The code also provides an extension which triggers a re-index after a page is published/unpublished in the SilverStripe CMS admin area.
+The code also provides an extension which triggers a re-index after a page is published/unpublished in the SilverStripe
+CMS admin area.
 
 ## How does it work?
 
 ### MetaTags
 
-There are a bunch of standard `SwiftypeMetaTag` classes. Each of these classes represents one of the standard SilverStripe SiteTree fields *or methods*, and will be used to output a single meta tag into your markup.
+There are a bunch of standard `SwiftypeMetaTag` classes. Each of these classes represents one of the standard
+SilverStripe SiteTree fields *or methods*, and will be used to output a single meta tag into your markup.
 
 Here are the standard classes, and which SiteTree field/method they represent:
+
 - SwiftypeMetaTagDescription (`MetaDescription` field)
 - SwiftypeMetaTagPublishedAt (`LastEdited` field)
 - SwiftypeMetaTagTitle (`Title` field)
 - SwiftypeMetaTagURL (`Link()` method)
 
+Additionally, there is a robots class, which can be used to output `noindex` and/or `nofollow` (configurable) when
+your SiteTree record has `ShowInSearch` set to `0`. By default, this will render with just `noidex`, but you can
+update it's config to also render with `nofollow`.
+
+- SwiftypeMetaTagRobots
+
 ### Templating
 
-If you are using out of the box functionality (see [Installation](#Installation)), then in your template, you can simply use `$SwiftypeMetaTags` to output all of the meta tags that you have set up as part of your install.
+If you are using out of the box functionality (see [Configuration](#Configuration)), then in your template, you can simply
+use `$SwiftypeMetaTags` to output all of the meta tags that you have set up as part of your install.
 
 ### Crawling
 
-If you are using out of the box functionality (see [Installation](#Installation)), then when you publish a page, a request will be sent to Swiftype for it to crawl that page.
+If you are using out of the box functionality (see [Configuration](#Configuration)), then when you publish a page, a
+request will be sent to Swiftype for it to crawl that page.
 
-_Note: At the time of writing this, Swiftype did not support re-crawling existing pages by request, it only supported the "first time" crawling of new pages. That might change though, and in either case, it doesn't hurt to fire the request off._
-
-## Installation
-
-```
-composer require ichaber/silverstripe-swiftype
-```
+## Configuration
 
 ### Simple
 
@@ -80,6 +89,7 @@ App\Page\MyPage:
   swiftype_meta_tag_classes:
     - Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagDescription
     - Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagPublishedAt
+    - Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots
     - Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagTitle
     - Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagURL
 ```
@@ -94,32 +104,47 @@ class MyPage extends SiteTree
     private static $swiftype_meta_tag_classes = [
         SwiftypeMetaTagDescription::class,
         SwiftypeMetaTagPublishedAt::class,
+        SwiftypeMetaTagRobots::class,
         SwiftypeMetaTagTitle::class,
         SwiftypeMetaTagURL::class,
     ];
 }
 ```
 
-Either of these methods should provide you with good control if you have different page types needing different meta tags.
+Either of these methods should provide you with good control if you have different page types needing different meta
+tags.
+
+**A quick note on the Robots class**
+
+Swiftype uses the standard `<meta name="robots" content="noindex">` meta tag, so if you are already outputting this tag
+through some other means, then you will want to exclude it here. Also see
+[Customising the robots Meta Tag](#Customising the robots Meta Tag)
 
 ### Piece by piece
 
-To use the standard SiteConfig CMS fields, you can apply `SwiftypeSiteConfigFieldsExtension` to your `SiteConfig`. This will provide you with some basic options to set up a single engine for your site
-Currently there is minimal support for multiple engines on a single site - you will (most likely) need to add your own implementation if you desire this.
+To use the standard SiteConfig CMS fields, you can apply `SwiftypeSiteConfigFieldsExtension` to your `SiteConfig`. This
+will provide you with some basic options to set up a single engine for your site.
+
+Currently there is minimal support for multiple engines on a single site - you will (most likely) need to add your own
+implementation if you desire this.
+
 ```yml
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - Ichaber\SSSwiftype\Extensions\SwiftypeSiteConfigFieldsExtension
 ```
 
-If you are using the Swiftype Crawler, and would like to add "re-crawl" actions after your pages publish, you can apply `SwiftypeSiteTreeCrawlerExtension` to `SiteTree` (or another model of your choice).
+If you are using the Swiftype Crawler, and would like to add "re-crawl" actions after your pages un/publish, you can
+apply `SwiftypeSiteTreeCrawlerExtension` to `SiteTree` (or another model of your choice).
+
 ```yml
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Ichaber\SSSwiftype\Extensions\SwiftypeSiteTreeCrawlerExtension
 ```
 
-If you would like SiteTree to have access to the standard template method, then apply the following extension.
+If you would like SiteTree to have access to the standard template variable, then apply the following extension.
+
 ```yml
 SilverStripe\CMS\Model\SiteTree:
   extensions:
@@ -133,6 +158,30 @@ You can easily add your own classes to your objects (see [Installation](#Install
 Any classes that you add are expected to implement `SwiftypeMetaTagInterface`, but that's about it.
 
 You can also feel free to extend `SwiftypeMetaTag`, if you would like access to methods like `generateMetaTagsString()`.
+
+## Customising the robots Meta Tag
+
+There are two configs available for the robots Meta Tag. These allow you to control whether you add `noindex` and/or 
+`nofollow`. By befault, `noindex` is added, but we allow robots to follow.
+
+```
+Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots:
+  no_index: true
+  no_follow: false
+```
+
+You can override these by adding your own config. EG: Adding both `noidex` and `nofollow`.
+
+```yml
+
+---
+Name: app_swiftype_tags
+After: swiftype_tags
+---
+Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots:
+  no_index: true
+  no_follow: true
+```
 
 ## Requirements
 

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -4,6 +4,9 @@ Name: swiftype_tags
 # Default date format for all Tags. You can set override this for all Tags, or set it differently for different classes
 Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTag:
   date_format: YYYY-MM-dd HH:mm:ss
+Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots:
+  no_index: true
+  no_follow: false
 # Example of setting a custom fieldName for an existing MetaTag class
 #Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagURL:
 #  field_name: AbsoluteLink

--- a/src/MetaTags/SwiftypeMetaTag.php
+++ b/src/MetaTags/SwiftypeMetaTag.php
@@ -35,6 +35,33 @@ abstract class SwiftypeMetaTag implements SwiftypeMetaTagInterface
 
     /**
      * @param DataObject $dataObject
+     * @return null|string
+     */
+    public function getMetaTagString(DataObject $dataObject): ?string
+    {
+        // Can't do anything if no tag name was specified
+        if ($this->name === null) {
+            return null;
+        }
+
+        // Can't do anything if no tag field type was specified
+        if ($this->fieldType === null) {
+            return null;
+        }
+
+        // Grab the value for this field (if we're able)
+        $fieldValue = $this->getFieldValue($dataObject);
+
+        // Can't do anything if there is no field value
+        if ($fieldValue === null) {
+            return null;
+        }
+
+        return $this->generateMetaTagsString($this->name, $this->fieldType, $fieldValue);
+    }
+
+    /**
+     * @param DataObject $dataObject
      * @return string|int|null
      */
     protected function getFieldValue(DataObject $dataObject)
@@ -98,32 +125,5 @@ abstract class SwiftypeMetaTag implements SwiftypeMetaTagInterface
             $fieldType,
             $value
         );
-    }
-
-    /**
-     * @param DataObject $dataObject
-     * @return null|string
-     */
-    public function getMetaTagString(DataObject $dataObject): ?string
-    {
-        // Can't do anything if no tag name was specified
-        if ($this->name === null) {
-            return null;
-        }
-
-        // Can't do anything if no tag field type was specified
-        if ($this->fieldType === null) {
-            return null;
-        }
-
-        // Grab the value for this field (if we're able)
-        $fieldValue = $this->getFieldValue($dataObject);
-
-        // Can't do anything if there is no field value
-        if ($fieldValue === null) {
-            return null;
-        }
-
-        return $this->generateMetaTagsString($this->name, $this->fieldType, $fieldValue);
     }
 }

--- a/src/MetaTags/SwiftypeMetaTagRobots.php
+++ b/src/MetaTags/SwiftypeMetaTagRobots.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ichaber\SSSwiftype\MetaTags;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class SwiftypeMetaTagRobots
+ *
+ * @package Ichaber\SSSwiftype\MetaTags
+ */
+class SwiftypeMetaTagRobots extends SwiftypeMetaTag
+{
+    /**
+     * @param DataObject $dataObject
+     * @return string|null
+     */
+    public function getMetaTagString(DataObject $dataObject): ?string
+    {
+        $value = $this->getFieldValue($dataObject);
+
+        if ($value === null) {
+            return null;
+        }
+
+        return sprintf('<meta name="robots" content="%s">', $value);
+    }
+
+    /**
+     * @param DataObject $dataObject
+     * @return int|string|null
+     */
+    protected function getFieldValue(DataObject $dataObject)
+    {
+        // This tag is only available for SiteTree objects
+        if (!$dataObject instanceof SiteTree) {
+            return null;
+        }
+
+        // Don't add the robots meta tag if we do want to show this in search
+        if ($dataObject->ShowInSearch) {
+            return null;
+        }
+
+        // Check config settings
+        $noFollow = Config::inst()->get(static::class, 'no_follow');
+        $noIndex = Config::inst()->get(static::class, 'no_index');
+
+        // Both configs are set to false, meaning you don't want to render out this tag
+        if (!$noFollow && !$noIndex) {
+            return null;
+        }
+
+        if (!$noFollow) {
+            return 'noindex';
+        }
+
+        if (!$noIndex) {
+            return 'nofollow';
+        }
+
+        return 'noindex, nofollow';
+    }
+}

--- a/tests/php/Extensions/SwiftypeMetaTagContentExtensionTest.php
+++ b/tests/php/Extensions/SwiftypeMetaTagContentExtensionTest.php
@@ -5,6 +5,7 @@ namespace Ichaber\SSSwiftype\Tests\Extensions;
 use Exception;
 use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagDescription;
 use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagPublishedAt;
+use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots;
 use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagTitle;
 use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagURL;
 use Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree;
@@ -46,6 +47,7 @@ class SwiftypeMetaTagContentExtensionTest extends SapphireTest
             [
                 SwiftypeMetaTagDescription::class,
                 SwiftypeMetaTagPublishedAt::class,
+                SwiftypeMetaTagRobots::class,
                 SwiftypeMetaTagTitle::class,
                 SwiftypeMetaTagURL::class,
             ]

--- a/tests/php/MetaTags/SwiftypeMetaTagPublishedAtTest.php
+++ b/tests/php/MetaTags/SwiftypeMetaTagPublishedAtTest.php
@@ -12,7 +12,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 /**
  * Class SwiftypeMetaTagPublishedAtTest
  *
- * @package Ichaber\SSSwiftype\Tests\Extensions
+ * @package Ichaber\SSSwiftype\Tests\MetaTags
  */
 class SwiftypeMetaTagPublishedAtTest extends SapphireTest
 {

--- a/tests/php/MetaTags/SwiftypeMetaTagRobotsTest.php
+++ b/tests/php/MetaTags/SwiftypeMetaTagRobotsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Tests\Extensions;
+
+use Ichaber\SSSwiftype\MetaTags\SwiftypeMetaTagRobots;
+use Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * Class SwiftypeMetaTagRobotsTest
+ *
+ * @package Ichaber\SSSwiftype\Tests\MetaTags
+ */
+class SwiftypeMetaTagRobotsTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'SwiftypeMetaTagTest.yml';
+
+    public function testRobotsTagNoIndex(): void
+    {
+        Config::inst()->update(
+            SwiftypeSiteTree::class,
+            'swiftype_meta_tag_classes',
+            [
+                SwiftypeMetaTagRobots::class,
+            ]
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_index',
+            true
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_follow',
+            false
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page2');
+
+        // Quickly render an expected mock
+        $mock = '<meta name="robots" content="noindex">';
+        $mock = trim(preg_replace("/\s+/S", '', $mock));
+
+        // Remove formatting from output output
+        $output = trim(preg_replace("/\s+/S", '', $page->getSwiftypeMetaTags()->getValue()));
+
+        $this->assertEquals($mock, $output);
+    }
+
+    public function testRobotsTagNoFollow(): void
+    {
+        Config::inst()->update(
+            SwiftypeSiteTree::class,
+            'swiftype_meta_tag_classes',
+            [
+                SwiftypeMetaTagRobots::class,
+            ]
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_index',
+            false
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_follow',
+            true
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page2');
+
+        // Quickly render an expected mock
+        $mock = '<meta name="robots" content="nofollow">';
+        $mock = trim(preg_replace("/\s+/S", '', $mock));
+
+        // Remove formatting from output output
+        $output = trim(preg_replace("/\s+/S", '', $page->getSwiftypeMetaTags()->getValue()));
+
+        $this->assertEquals($mock, $output);
+    }
+
+    public function testRobotsTagBoth(): void
+    {
+        Config::inst()->update(
+            SwiftypeSiteTree::class,
+            'swiftype_meta_tag_classes',
+            [
+                SwiftypeMetaTagRobots::class,
+            ]
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_index',
+            true
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_follow',
+            true
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page2');
+
+        // Quickly render an expected mock
+        $mock = '<meta name="robots" content="noindex, nofollow">';
+        $mock = trim(preg_replace("/\s+/S", '', $mock));
+
+        // Remove formatting from output output
+        $output = trim(preg_replace("/\s+/S", '', $page->getSwiftypeMetaTags()->getValue()));
+
+        $this->assertEquals($mock, $output);
+    }
+
+    public function testRobotsTagNone(): void
+    {
+        Config::inst()->update(
+            SwiftypeSiteTree::class,
+            'swiftype_meta_tag_classes',
+            [
+                SwiftypeMetaTagRobots::class,
+            ]
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_index',
+            false
+        );
+
+        Config::inst()->update(
+            SwiftypeMetaTagRobots::class,
+            'no_follow',
+            false
+        );
+
+        /** @var SwiftypeSiteTree $page */
+        $page = $this->objFromFixture(SwiftypeSiteTree::class, 'page2');
+
+        // Remove formatting from output output
+        $output = trim(preg_replace("/\s+/S", '', $page->getSwiftypeMetaTags()->getValue()));
+
+        $this->assertEquals('', $output);
+    }
+}

--- a/tests/php/MetaTags/SwiftypeMetaTagTest.yml
+++ b/tests/php/MetaTags/SwiftypeMetaTagTest.yml
@@ -3,3 +3,8 @@ Ichaber\SSSwiftype\Tests\Fake\SwiftypeSiteTree:
     URLSegment: page1
     Title: Page 1
     MetaDescription: Page 1 Meta Description
+  page2:
+    URLSegment: page2
+    Title: Page 2
+    MetaDescription: Page 2 Meta Description
+    ShowInSearch: 0

--- a/tests/php/MetaTags/SwiftypeMetaTagURLTest.php
+++ b/tests/php/MetaTags/SwiftypeMetaTagURLTest.php
@@ -12,7 +12,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 /**
  * Class SwiftypeMetaTagURLTest
  *
- * @package Ichaber\SSSwiftype\Tests\Extensions
+ * @package Ichaber\SSSwiftype\Tests\MetaTags
  */
 class SwiftypeMetaTagURLTest extends SapphireTest
 {


### PR DESCRIPTION
Fixed #20 

## Addition

Added new Meta Tag:

- `SwiftypeMetaTagRobots`

The purpose of this tag is to output `<meta name="robots" content="...">` to the template when `ShowInSearch` is set to `0`.

There are two configurable values:

- `no_index` (default `true`)
- `no_follow (default `false`)

If both are set to `false`, then, of course the tag will not be rendered at all.

Possible outputs are:

`<meta name="robots" content="noindex">`
`<meta name="robots" content="nofollow">`
`<meta name="robots" content="noindex, nofollow">`

## Other changes

- Updated docs
- Moved `public` method above `protected` method