### PR TITLE
WIP: Feature: Swiftype reindex crawler for File class

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,19 @@ SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Ichaber\SSSwiftype\Extensions\SwiftypeSiteTreeCrawlerExtension
     - Ichaber\SSSwiftype\Extensions\SwiftypeMetaTagContentExtension
+SilverStripe\Assets\File:
+  extensions:
+    - Ichaber\SSSwiftype\Extensions\SwiftypeFileCrawlerExtension
+Ichaber\SSSwiftype\Extensions\SwiftypeFileCrawlerExtension:
+  reindex_files_whitelist:
+    - pdf
 ```
 
 These will provide you with:
 - The standard CMS fields for adding your Swiftype credentials.
 - A template variable (`$SwiftypeMetaTags`) for outputting your meta tags.
 - Re-index requests to Swiftype on SiteTree publishing.
+- Re-index requests to Swiftype on File publishing (on specific file type(s) e.g. 'pdf').
 
 You will then need specify which Meta Tags you would like to use. You can do this in two ways.
 
@@ -121,6 +128,17 @@ SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Ichaber\SSSwiftype\Extensions\SwiftypeSiteTreeCrawlerExtension
 ```
+
+if you are using the Swiftype Crawler, and would like to add "re-crawl" actions after your files publish, you can apply `SwiftypeFileCrawlerExtension` to `File`.
+```YML
+SilverStripe\Assets\File:
+  extensions:
+    - Ichaber\SSSwiftype\Extensions\SwiftypeFileCrawlerExtension
+Ichaber\SSSwiftype\Extensions\SwiftypeFileCrawlerExtension:
+  reindex_files_whitelist:
+    - pdf
+```
+> `reindex_files_whitelist` config parameter can be used to whitelist which file types you wish to re-crawl.
 
 If you would like SiteTree to have access to the standard template method, then apply the following extension.
 ```yml

--- a/src/Extensions/SwiftypeFileCrawlerExtension.php
+++ b/src/Extensions/SwiftypeFileCrawlerExtension.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Extensions;
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\SiteConfig\SiteConfig;
+
+/**
+ * Class SwiftypeFileCrawlerExtension
+ *
+ * @package Ichaber\SSSwiftype\Extensions
+ * @property DataObject|$this $owner
+ */
+class SwiftypeFileCrawlerExtension extends DataExtension
+{
+    /**
+     * @param DataObject|mixed $original
+     */
+    public function onAfterPublish(&$original): void
+    {
+        parent::onAfterPublish($original);
+
+        $this->forceSwiftypeIndex();
+    }
+
+    public function onAfterUnpublish(): void
+    {
+        parent::onAfterUnpublish();
+
+        $this->forceSwiftypeIndex();
+    }
+
+    /**
+     * According to the documentation of the RestfulService only xml output is supported at this stage.
+     * As we need json, we opted to just use standard PHP curl processing.
+     *
+     * For future proofing purposes, this function returns a boolean value.
+     *
+     * Note: This request to Swiftype is ignored any time a request is sent for an existing URL (unfortunately). For
+     * reindexing edited Pages, we must unfortunately rely on Constant Crawl. This is probably a design choice on
+     * Swiftype's part.
+     *
+     * @return bool
+     */
+    protected function forceSwiftypeIndex(): bool
+    {
+        /** @var SiteConfig $config */
+        $config = SiteConfig::current_site_config();
+        $logger = $this->getLogger();
+
+        // Are you not using SwiftypeSiteConfigFieldsExtension? That's cool, just be sure to implement these as fields
+        // or methods in some other manor so that they are available via relField.
+
+        // You might want to implement this via Environment variables or something. Just make sure SiteConfig has access
+        // to that variable, and return it here.
+        $swiftypeEnabled = (bool) $config->relField('SwiftypeEnabled');
+
+        // If you have multiple Engines per site (maybe you use Fluent with a different Engine on each Locale), then
+        // this provides some basic ability to have different credentials returned based on the application state.
+        $engineSlug = $config->relField('SwiftypeEngineSlug');
+        $domainID = $config->relField('SwiftypeDomainID');
+        $apiKey = $config->relField('SwiftypeAPIKey');
+
+        if (!$swiftypeEnabled) {
+            return true;
+        }
+
+        if (!$engineSlug) {
+            $trace = debug_backtrace();
+            $logger->warning(
+                'Swiftype Engine Slug value has not been set. Settings > Swiftype Search > Swiftype Engine Slug',
+                array_shift($trace) // Add context (for RaygunHandler) by using the last item on the stack trace.
+            );
+
+            return false;
+        }
+
+        if (!$domainID) {
+            $trace = debug_backtrace();
+            $logger->warning(
+                'Swiftype Domain ID has not been set. Settings > Swiftype Search > Swiftype Domain ID',
+                array_shift($trace) // Add context (for RaygunHandler) by using the last item on the stack trace.
+            );
+
+            return false;
+        }
+
+        if (!$apiKey) {
+            $trace = debug_backtrace();
+            $logger->warning(
+                'Swiftype API Key has not been set. Settings > Swiftype Search > Swiftype Production API Key',
+                array_shift($trace) // Add context (for RaygunHandler) by using the last item on the stack trace.
+            );
+
+            return false;
+        }
+
+        $updateUrl = $this->getOwner()->getAbsoluteURL();
+
+        // Create curl resource.
+        $ch = curl_init();
+
+        // Set url.
+        curl_setopt(
+            $ch,
+            CURLOPT_URL,
+            sprintf(
+                'https://api.swiftype.com/api/v1/engines/%s/domains/%s/crawl_url.json',
+                $engineSlug,
+                $domainID
+            )
+        );
+
+        // Set request method to "PUT".
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        // Set headers.
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+        ]);
+
+        // Return the transfer as a string.
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        // Set our PUT values.
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
+            'auth_token' => $apiKey,
+            'url' => $updateUrl,
+        ]));
+
+        // $output contains the output string.
+        $output = curl_exec($ch);
+
+        // Close curl resource to free up system resources.
+        curl_close($ch);
+
+        if (!$output) {
+            $trace = debug_backtrace();
+            $logger->warning(
+                'We got no response from Swiftype for reindexing page: ' . $updateUrl,
+                array_shift($trace) // Add context (for RaygunHandler) by using the last item on the stack trace.
+            );
+
+            return false;
+        }
+
+        $jsonOutput = json_decode($output, true);
+        if (!empty($jsonOutput) && array_key_exists('error', $jsonOutput)) {
+            $message = $jsonOutput['error'];
+            $context = ['exception' => new Exception($message)];
+
+            // Add context (for RaygunHandler) by using the last item on the stack trace.
+            $logger->warning($message, $context);
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return LoggerInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function getLogger(): LoggerInterface
+    {
+        return Injector::inst()->get(LoggerInterface::class);
+    }
+}

--- a/src/Extensions/SwiftypeSiteTreeCrawlerExtension.php
+++ b/src/Extensions/SwiftypeSiteTreeCrawlerExtension.php
@@ -3,6 +3,7 @@
 namespace Ichaber\SSSwiftype\Extensions;
 
 use Exception;
+use Ichaber\SSSwiftype\Traits\SwiftypeIndexCrawlerTrait;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
 use SilverStripe\CMS\Model\SiteTree;
@@ -18,6 +19,8 @@ use SilverStripe\SiteConfig\SiteConfig;
  */
 class SwiftypeSiteTreeCrawlerExtension extends SiteTreeExtension
 {
+    use SwiftypeIndexCrawlerTrait;
+
     /**
      * @param SiteTree|mixed $original
      */
@@ -103,41 +106,7 @@ class SwiftypeSiteTreeCrawlerExtension extends SiteTreeExtension
         $updateUrl = $this->getOwner()->getAbsoluteLiveLink();
 
         // Create curl resource.
-        $ch = curl_init();
-
-        // Set url.
-        curl_setopt(
-            $ch,
-            CURLOPT_URL,
-            sprintf(
-                'https://api.swiftype.com/api/v1/engines/%s/domains/%s/crawl_url.json',
-                $engineSlug,
-                $domainID
-            )
-        );
-
-        // Set request method to "PUT".
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
-
-        // Set headers.
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Content-Type: application/json',
-        ]);
-
-        // Return the transfer as a string.
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-        // Set our PUT values.
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
-            'auth_token' => $apiKey,
-            'url' => $updateUrl,
-        ]));
-
-        // $output contains the output string.
-        $output = curl_exec($ch);
-
-        // Close curl resource to free up system resources.
-        curl_close($ch);
+        $output = $this->buildCurlRequest($engineSlug, $domainID, $apiKey, $updateUrl);
 
         if (!$output) {
             $trace = debug_backtrace();

--- a/src/Traits/SwiftypeIndexCrawlerTrait.php
+++ b/src/Traits/SwiftypeIndexCrawlerTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ichaber\SSSwiftype\Traits;
+
+/**
+ * Trait SwiftypeIndexCrawlerTrait
+ *
+ * Shared functionality to be used across SwiftypeFileCrawler and SwiftypeSiteTreeCrawler extensions
+ * to build curl requests.
+ *
+ * @package Ichaber\SSSwiftype\Traits
+ */
+trait SwiftypeIndexCrawlerTrait
+{
+    public function buildCurlRequest(string $engineSlug, string $domainID, string $apiKey, string $updateUrl) {
+        // Create curl resource.
+        $ch = curl_init();
+
+        // Set url.
+        curl_setopt(
+            $ch,
+            CURLOPT_URL,
+            sprintf(
+                'https://api.swiftype.com/api/v1/engines/%s/domains/%s/crawl_url.json',
+                $engineSlug,
+                $domainID
+            )
+        );
+
+        // Set request method to "PUT".
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+
+        // Set headers.
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+        ]);
+
+        // Return the transfer as a string.
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        // Set our PUT values.
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode([
+            'auth_token' => $apiKey,
+            'url' => $updateUrl,
+        ]));
+
+        // $output contains the output string.
+        return $output = curl_exec($ch);
+    }
+
+}


### PR DESCRIPTION
## Feature: Swiftype reindex crawler for File class

- new `SwiftypeFileCrawlerExtension` class created to allow re-crawl actions on `File::class`
- new `SwiftypeIndexCrawlerTrait` trait created to help negate any code duplication for building and executing cURL requests.
- updated read me docs to include instructions for installing this new reindex class

#### Peer Review Checklist

- [ ] Matches all Acceptance Criteria
- [ ] Runs without issue locally
- [ ] CircleCI test deployment approved
